### PR TITLE
Removing direct writing writing and deadlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,5 @@ sitemap.PingSearchEngines("http://exemple.com/index.xml.gz")
 
 
 
-##Example
+## Example
 There is a very simple example of using the example folder.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/StudioSol/sitemap
+
+go 1.13

--- a/ping.go
+++ b/ping.go
@@ -1,6 +1,7 @@
 package sitemap
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"sync"
@@ -10,16 +11,14 @@ import (
 //Currently supports Google and Bing.
 func PingSearchEngines(indexFile string) {
 	var urls = []string{
-		"http://www.google.com/webmasters/tools/ping?sitemap=" + indexFile,
-		"http://www.bing.com/ping?sitemap=" + indexFile,
+		fmt.Sprintf("http://www.google.com/ping?sitemap=%s", indexFile),
+		fmt.Sprintf("http://www.bing.com/ping?sitemap=%s", indexFile),
 	}
 
 	results := asyncHttpGets(urls)
-
 	for result := range results {
 		log.Printf("%s status: %s\n", result.url, result.response.Status)
 	}
-
 }
 
 type HttpResponse struct {

--- a/sitemap.go
+++ b/sitemap.go
@@ -14,14 +14,10 @@ import (
 //If the sitemap exceed the limit of 50k urls, new sitemaps will have a numeric suffix to the name. Example:
 //- blog_1.xml.gz
 //- blog_2.xml.gz
-func NewSitemapGroup(folder string, name string, isMobile bool) (*SitemapGroup, error) {
+func NewSitemapGroup(name string, isMobile bool) *SitemapGroup {
 	s := new(SitemapGroup)
-	err := s.Configure(name, folder, isMobile)
-	if err != nil {
-		return s, err
-	}
-	go s.Initialize()
-	return s, nil
+	s.Configure(name, isMobile)
+	return s
 }
 
 //Creates a new group of sitemaps indice that used a common name.
@@ -41,7 +37,6 @@ func NewIndexGroup(folder string, name string) (*IndexGroup, error) {
 //Search all the xml.gz sitemaps_dir directory, uses the modified date of the file as lastModified
 //path_index is included for the function does not include the url of the index in your own content, if it is present in the same directory.
 func CreateIndexByScanDir(targetDir string, indexFileName string, public_url string) (index Index) {
-
 	index = Index{Sitemaps: []Sitemap{}}
 
 	fs, err := ioutil.ReadDir(targetDir)
@@ -60,22 +55,18 @@ func CreateIndexByScanDir(targetDir string, indexFileName string, public_url str
 
 //Returns an index sitemap starting from a slice of urls
 func CreateIndexBySlice(urls []string, public_url string) (index Index) {
-
 	index = Index{Sitemaps: []Sitemap{}}
-
 	if len(urls) > 0 {
 		for _, fileName := range urls {
 			lastModified := time.Now()
 			index.Sitemaps = append(index.Sitemaps, Sitemap{Loc: public_url + fileName, LastMod: &lastModified})
 		}
 	}
-
 	return
 }
 
 //Creates and gzip the xml index
 func CreateSitemapIndex(indexFilePath string, index Index) (err error) {
-
 	//create xml
 	indexXml, err := createSitemapIndexXml(index)
 	if err != nil {

--- a/xml.go
+++ b/xml.go
@@ -97,15 +97,13 @@ func createSitemapIndexXml(index Index) (indexXML []byte, err error) {
 		indexXML = append(indexXML, sitemapIndexXML...)
 	}
 	if len(indexXML) > MAXFILESIZE {
-		err = ErrMaxFileSize
-		return
+		return nil, ErrMaxFileSize
 	}
 	return
 }
 
 //Save and gzip xml
 func saveXml(xmlFile []byte, path string) (err error) {
-
 	fo, err := os.Create(path)
 	defer fo.Close()
 


### PR DESCRIPTION
- Small changes in async calls.
- The file is not write in disk directly.
- Include Go Modules
- Update Google Ping URL.

### How to test
- cd example
- go run example_sitemap_groups.go